### PR TITLE
Improvements

### DIFF
--- a/site-health-tool-manager.php
+++ b/site-health-tool-manager.php
@@ -107,9 +107,11 @@ function shtm_settings_page() { ?>
 
 			// Validate that submitted tests are actually registered
 			$test_names = array_merge( $tests['direct'], $tests['async'] );
-			foreach ( $_POST['checked'] as $name ) {
-				if ( isset( $test_names[ $name ] ) ) {
-					$enabled[] = $name;
+			if ( isset( $_POST['checked'] ) ) {
+				foreach ( $_POST['checked'] as $name ) {
+					if ( isset( $test_names[ $name ] ) ) {
+						$enabled[] = $name;
+					}
 				}
 			}
 

--- a/site-health-tool-manager.php
+++ b/site-health-tool-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: Site Health Tool Manager
  * Plugin URI:  https://github.com/earnjam/site-health-tool-manager
  * Description: Control which tests appear in the the Site Health Tool
- * Version:     1.2
+ * Version:     1.3
  * Author:      William Earnhardt
  * Author URI:  https://wearnhardt.com
  * License:     GPL2
@@ -34,7 +34,8 @@ add_action( 'admin_menu', 'shtm_add_settings_page', 10 );
  */
 function shtm_filter_tests( $tests ) {
 	// Don't filter on the plugin settings page
-	if ( get_current_screen()->base !== 'settings_page_shtm-settings' ) {
+	$scr = get_current_screen();
+	if ( property_exists($scr, 'base') !== true || $scr->base !== 'settings_page_shtm-settings' ) {
 		$hidden_tests = (array) maybe_unserialize( get_option( 'shtm_hidden_tests' ) );
 		foreach ( $hidden_tests as $test ) {
 			unset( $tests['direct'][ $test ] );

--- a/site-health-tool-manager.php
+++ b/site-health-tool-manager.php
@@ -162,7 +162,6 @@ function shtm_settings_page() { ?>
 					echo 'name="checked[]" id="' . $test . '" value="' . $test . '" />';
 					
 					// Fallback for tests that don't set label and/or use class-based checks
-					$label = $details['label'];
 					if ( isset( $details['label'] ) ) {
 						$label = $details['label'];
 					} else if ( is_array( $details ) ) { 

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,7 @@
+<?php
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) exit;
+
+delete_option( 'shtm_hidden_tests' );
+delete_option( 'shtm_widget_enabled' );
+delete_option( 'shtm_hidden_modules' );


### PR DESCRIPTION
Hi William,

nice plugin. I made a couple improvements. Turning off the PHP Extension check is a bit too general, so I added an option to exclude only specific extensions (modules) using another filter. 

Also the labels for checks from other plugins did not work properly on the settings page. The Yoast SEO plugin for example, does not maintain the label. I display the name of the underlying class instead as a label.

Best,
Marc